### PR TITLE
Fix server log to use custom port

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,5 +71,5 @@ app.post('/analyze-release-update', async (req, res) => {
 // --- Avvia il server ---
 app.listen(port, () => {
     console.log(`Server backend in ascolto su http://localhost:${port}`);
-    console.log('Endpoint per l\'analisi AI: POST http://localhost:3000/analyze-release-update');
+    console.log(`Endpoint per l'analisi AI: POST http://localhost:${port}/analyze-release-update`);
 });


### PR DESCRIPTION
## Summary
- log AI analysis endpoint with the configured port

## Testing
- `npm test` *(fails: Error: no test specified)*
- `PORT=5001 node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6841f36aa7908324995ea8d3d51b3195