### PR TITLE
Add analyze-license-adoption endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSM AI Backend
 
-This backend uses the Gemini API to analyze release updates and Proactive Monitoring alerts.
+This backend uses the Gemini API to analyze release updates, license adoption data and Proactive Monitoring alerts.
 
 ## Setting up `GEMINI_API_KEY`
 


### PR DESCRIPTION
## Summary
- add a new `/analyze-license-adoption` endpoint
- log the new endpoint when the server starts
- document that license adoption is supported

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846e9e75ee083249a0418179ff5d8c0