### PR TITLE
Add root health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 This backend uses the Gemini API to analyze release updates, license adoption data and Proactive Monitoring alerts.
 
+## Usage
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+By default the application listens on port `3000`. You can verify it is running by hitting the health endpoint:
+
+```bash
+curl http://localhost:3000/
+```
+
+It should respond with:
+
+```json
+{"status":"ok"}
+```
+
 ## Setting up `GEMINI_API_KEY`
 
 A valid API key is required for the Gemini API calls. You can provide it in two ways:

--- a/server.js
+++ b/server.js
@@ -38,6 +38,11 @@ app.use(cors({
 // Middleware per parsare il corpo delle richieste in formato JSON
 app.use(express.json());
 
+// Endpoint di salute
+app.get('/', (req, res) => {
+    res.json({ status: 'ok' });
+});
+
 // --- Endpoint per l'analisi con Gemini ---
 app.post('/analyze-release-update', async (req, res) => {
     console.log('Richiesta ricevuta per /analyze-release-update');


### PR DESCRIPTION
## Summary
- add a basic health check endpoint
- document server usage and health endpoint in the README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ad067cf388324a0b184f8197604ad